### PR TITLE
Fix/host only accept alphadash on install

### DIFF
--- a/app/Http/Requests/Install/Database.php
+++ b/app/Http/Requests/Install/Database.php
@@ -24,7 +24,7 @@ class Database extends FormRequest
     public function rules()
     {
         return [
-            'host' => ['required', 'alpha_dash'],
+            'host' => ['required', 'ip'],
             'name' => ['required', 'alpha_dash'],
             'username' => ['required', 'alpha_dash'],
             'password' => ['required'],

--- a/resources/views/app/install/components/database.blade.php
+++ b/resources/views/app/install/components/database.blade.php
@@ -14,7 +14,7 @@
            @error('host') :error="true"
            error-message="{{ $message }}"
            @enderror
-           :prepend="true" name="host" :validation="['ip']"
+           :prepend="true" name="host" :validation="['required', 'ip']"
   ></v-input>
   <v-input icon="fa-database"
            placeholder="{{ __('app.install.placeholder.database.name') }}"

--- a/resources/views/app/install/components/database.blade.php
+++ b/resources/views/app/install/components/database.blade.php
@@ -8,13 +8,13 @@
   @csrf
   <v-input icon="fa-database"
            placeholder="{{ __('app.install.placeholder.database.host') }}"
-           default-value="localhost"
+           default-value="127.0.0.1"
            old="{{ old('host') }}"
            default-value="host"
            @error('host') :error="true"
            error-message="{{ $message }}"
            @enderror
-           :prepend="true" name="host" :validation="['required', 'alpha_dash']"
+           :prepend="true" name="host" :validation="['ip']"
   ></v-input>
   <v-input icon="fa-database"
            placeholder="{{ __('app.install.placeholder.database.name') }}"


### PR DESCRIPTION
issue #60 
prefer using ip validation rather than alphadash. because sometimes someone use remote database accessed with ip.
in my case im using mariadb-server docker which can be accessed only with 127.0.0.1 not localhost