### PR TITLE
fix(session): we don't need to specify session_domain

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -155,10 +155,7 @@ return [
     |
     */
 
-    'domain' => env(
-        'SESSION_DOMAIN',
-        Str::after(env('APP_URL'), 'https://')
-    ),
+    'domain' => null,
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
The bug came out because we use multi-tenant, due to this case I decided to change the session_domain to null