### PR TITLE
fix: calculate total discount per item and grand total discount selling in product report & selling report

### DIFF
--- a/app/Services/Tenants/ProductReportService.php
+++ b/app/Services/Tenants/ProductReportService.php
@@ -50,15 +50,18 @@ class ProductReportService
         $totalGrossProfit = 0;
         $totalDiscount = 0;
         $totalDiscountPerItem = 0;
+        $totalAllDiscountPerItem = 0;
         $totalNetProfitBeforeDiscountSelling = 0;
         $totalNetProfitAfterDiscountSelling = 0;
 
         /** @var Product $product */
         foreach ($products as $product) {
             $sellingDetails = $product->sellingDetails;
+            $totalAllDiscountPerItemTemp = 0;
 
             $totalCostPerSelling = $sellingDetails->sum('cost');
             $totalDiscountPerItem = $sellingDetails->sum('discount_price');
+            $totalAllDiscountPerItemTemp += $sellingDetails->sum('discount_price');
             $totalBeforeDiscountPerSelling = $sellingDetails->sum('price');
             $totalAfterDiscountPerSelling = $totalBeforeDiscountPerSelling - $totalDiscountPerItem;
             $totalNetProfitPerSelling = (($totalBeforeDiscountPerSelling - $totalCostPerSelling) - $totalDiscountPerItem);
@@ -88,7 +91,7 @@ class ProductReportService
             $totalNetProfitBeforeDiscountSelling += $totalNetProfitPerSelling;
             $totalNetProfitAfterDiscountSelling += ($totalNetProfitPerSelling - ($selling->discount_price ?? 0));
             $totalGrossProfit += $totalGrossProfitPerSelling;
-            $totalDiscountPerItem += $totalDiscountPerItem;
+            $totalAllDiscountPerItem += $totalAllDiscountPerItemTemp;
             $totalQty += $totalQtyPerSelling;
         }
 
@@ -98,6 +101,7 @@ class ProductReportService
             'total_net' => $this->formatCurrency($totalNet - $totalDiscount),
             'total_discount' => $this->formatCurrency($totalDiscount),
             'total_discount_per_item' => $this->formatCurrency($totalDiscountPerItem),
+            'total_all_discount_per_item' => $this->formatCurrency($totalAllDiscountPerItem),
             'total_gross_profit' => $this->formatCurrency($totalGross - $totalCost),
             'total_net_profit_before_discount_selling' => $this->formatCurrency($totalNet - $totalCost),
             'total_net_profit_after_discount_selling' => $this->formatCurrency($totalNet - $totalDiscount - $totalCost),

--- a/app/Services/Tenants/ProductReportService.php
+++ b/app/Services/Tenants/ProductReportService.php
@@ -83,16 +83,18 @@ class ProductReportService
                 'gross_profit' => $this->formatCurrency($totalBeforeDiscountPerSelling - $totalCostPerSelling),
             ];
 
-            $selling = $sellingDetails->first()->selling;
             $totalCost += $totalCostPerSelling;
-            $totalDiscount += ($selling->discount_price ?? 0);
             $totalGross += $totalBeforeDiscountPerSelling;
             $totalNet += $totalAfterDiscountPerSelling;
             $totalNetProfitBeforeDiscountSelling += $totalNetProfitPerSelling;
-            $totalNetProfitAfterDiscountSelling += ($totalNetProfitPerSelling - ($selling->discount_price ?? 0));
             $totalGrossProfit += $totalGrossProfitPerSelling;
             $totalAllDiscountPerItem += $totalAllDiscountPerItemTemp;
             $totalQty += $totalQtyPerSelling;
+
+            foreach ($sellingDetails as $sellingDetail) {
+                $totalDiscount += ($sellingDetail->selling->discount_price ?? 0.0);
+                $totalNetProfitAfterDiscountSelling += ($totalNetProfitPerSelling - ($sellingDetail->selling->discount_price ?? 0.0));
+            }
         }
 
         $footer = [

--- a/app/Services/Tenants/SellingReportService.php
+++ b/app/Services/Tenants/SellingReportService.php
@@ -54,7 +54,7 @@ class SellingReportService
 
         /** @var Selling $selling */
         foreach ($sellings as $selling) {
-            $totalDiscountPerItem = 0;
+            $totalDiscountPerItemTemp = 0;
             $totalBeforeDiscountPerSelling = 0;
             $totalAfterDiscountPerSelling = 0;
             $totalNetProfitPerSelling = 0;
@@ -64,7 +64,7 @@ class SellingReportService
 
             /** @var SellingDetail $detail */
             foreach ($selling->sellingDetails as $detail) {
-                $totalDiscountPerItem += ($detail->discount_price ?? 0);
+                $totalDiscountPerItemTemp += ($detail->discount_price ?? 0);
                 $totalBeforeDiscountPerSelling += $detail->price;
                 $totalAfterDiscountPerSelling += ($detail->price - ($detail->discount_price ?? 0));
                 $totalNetProfitPerSelling += (($detail->price - $detail->cost) - ($detail->discount_price ?? 0));
@@ -95,7 +95,7 @@ class SellingReportService
             $totalNetProfitBeforeDiscountSelling += $totalNetProfitPerSelling;
             $totalNetProfitAfterDiscountSelling += ($totalNetProfitPerSelling - ($selling->discount_price ?? 0));
             $totalGrossProfit += $totalGrossProfitPerSelling;
-            $totalDiscountPerItem += $totalDiscountPerItem;
+            $totalDiscountPerItem += $totalDiscountPerItemTemp;
             $totalQty += $totalQtyPerSelling;
         }
 
@@ -103,6 +103,8 @@ class SellingReportService
             'total_cost' => $this->formatCurrency($totalCost),
             'total_gross' => $this->formatCurrency($totalGross),
             'total_net' => $this->formatCurrency($totalNet - $totalDiscount),
+            'total_net_price_after_discount_per_item' => $this->formatCurrency($totalNet),
+            'total_net_price_after_discount_selling' => $this->formatCurrency($totalNet - $totalDiscount),
             'total_discount' => $this->formatCurrency($totalDiscount),
             'total_discount_per_item' => $this->formatCurrency($totalDiscountPerItem),
             'total_gross_profit' => $this->formatCurrency($totalGross - $totalCost),

--- a/resources/views/reports/partials/product-data.blade.php
+++ b/resources/views/reports/partials/product-data.blade.php
@@ -37,7 +37,7 @@
         <x-table-cell colspan="3">{{ __('Total') }}</x-table-cell>
         <x-table-cell class="number">{{ $footer['total_qty'] }}</x-table-cell>
         <x-table-cell class="number">{{ $footer['total_gross'] }}</x-table-cell>
-        <x-table-cell class="number">{{ $footer['total_discount_per_item'] }}</x-table-cell>
+        <x-table-cell class="number">{{ $footer['total_all_discount_per_item'] }}</x-table-cell>
         <x-table-cell class="number">{{ $footer['total_net'] }}</x-table-cell>
         <x-table-cell class="number">{{ $footer['total_gross_profit'] }}</x-table-cell>
         <x-table-cell class="number">{{ $footer['total_net_profit_before_discount_selling'] }}</x-table-cell>
@@ -66,7 +66,7 @@
         <x-table-cell class="number"><b>{{ $footer['total_cost'] }}</b></x-table-cell>
         <x-table-cell class="number"><b>{{ $footer['total_gross'] }}</b></x-table-cell>
         <x-table-cell class="number"><b>{{ $footer['total_discount'] }}</b></x-table-cell>
-        <x-table-cell class="number"><b>{{ $footer['total_discount_per_item'] }}</b></x-table-cell>
+        <x-table-cell class="number"><b>{{ $footer['total_all_discount_per_item'] }}</b></x-table-cell>
         <x-table-cell class="number"><b>{{ $footer['total_net'] }}</b></x-table-cell>
         <x-table-cell class="number"><b>{{ $footer['total_gross_profit'] }}</b></x-table-cell>
         <x-table-cell class="number"><b>{{ $footer['total_net_profit_before_discount_selling'] }}</b></x-table-cell>

--- a/resources/views/reports/partials/selling-data.blade.php
+++ b/resources/views/reports/partials/selling-data.blade.php
@@ -37,7 +37,7 @@
         <x-table-cell class="number">{{ $footer['total_qty'] }}</x-table-cell>
         <x-table-cell class="number">{{ $footer['total_gross'] }}</x-table-cell>
         <x-table-cell class="number">{{ $footer['total_discount_per_item'] }}</x-table-cell>
-        <x-table-cell class="number">{{ $footer['total_net'] }}</x-table-cell>
+        <x-table-cell class="number">{{ $footer['total_net_price_after_discount_per_item'] }}</x-table-cell>
         <x-table-cell class="number">{{ $footer['total_gross_profit'] }}</x-table-cell>
         <x-table-cell class="number">{{ $footer['total_net_profit_before_discount_selling'] }}</x-table-cell>
       </x-table-row>
@@ -66,7 +66,7 @@
         <x-table-cell class="number"><b>{{ $footer['total_gross'] }}</b></x-table-cell>
         <x-table-cell class="number"><b>{{ $footer['total_discount'] }}</b></x-table-cell>
         <x-table-cell class="number"><b>{{ $footer['total_discount_per_item'] }}</b></x-table-cell>
-        <x-table-cell class="number"><b>{{ $footer['total_net'] }}</b></x-table-cell>
+        <x-table-cell class="number"><b>{{ $footer['total_net_price_after_discount_per_item'] }}</b></x-table-cell>
         <x-table-cell class="number"><b>{{ $footer['total_gross_profit'] }}</b></x-table-cell>
         <x-table-cell class="number"><b>{{ $footer['total_net_profit_before_discount_selling'] }}</b></x-table-cell>
         <x-table-cell class="number"><b>{{ $footer['total_net_profit_after_discount_selling'] }}</b></x-table-cell>


### PR DESCRIPTION
Before in product report:
<img width="674" alt="Screenshot 2025-03-21 205050" src="https://github.com/user-attachments/assets/94d4914f-0b32-4004-8579-a190626e7949" />

After in product report:
<img width="662" alt="Screenshot 2025-03-21 205002" src="https://github.com/user-attachments/assets/74fcb0fd-7e9f-4616-80e9-1e6a341ef08d" />

---

Before in selling report:
<img width="678" alt="Screenshot 2025-03-20 140641" src="https://github.com/user-attachments/assets/6450aebe-5010-4e62-95bb-5b599d728c97" />

After in selling report:
<img width="680" alt="Screenshot 2025-03-20 140828" src="https://github.com/user-attachments/assets/a7c11989-d5df-4157-a513-cbd25dd754c9" />
