### PR TITLE
Make modifications to allow migration/seeding in sqlite environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@
 2. Navigate to the project directory: cd lakasir
 3. Install dependencies:
 4. Laravel:
-   * `composer install`
    * `cp .env.example .env`
    * edit the env based on your local configuration
+   * `composer install`
    * `php artisan key:generate`
    * `php artisan migrate --path=database/migrations/tenant --seed`
    * `php artisan filament:assets`

--- a/database/migrations/tenant/2024_08_17_155505_rename_foreign_key_in_receivables.php
+++ b/database/migrations/tenant/2024_08_17_155505_rename_foreign_key_in_receivables.php
@@ -12,10 +12,10 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('receivables', function (Blueprint $table) {
-            $table->dropForeign('debts_member_id_foreign');
+            $table->dropForeign(['member_id']);
             $table->foreign(['member_id'])->references('id')->on('members')->onDelete('cascade');
 
-            $table->dropForeign('debts_selling_id_foreign');
+            $table->dropForeign(['selling_id']);
             $table->foreign(['selling_id'])->references('id')->on('sellings')->onDelete('cascade');
         });
     }

--- a/database/migrations/tenant/2024_08_17_234032_rename_foreign_key_in_receivable_payments.php
+++ b/database/migrations/tenant/2024_08_17_234032_rename_foreign_key_in_receivable_payments.php
@@ -12,13 +12,13 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('receivable_payments', function (Blueprint $table) {
-            $table->dropForeign('debt_payments_debt_id_foreign');
+            $table->dropForeign(['receivable_id']);
             $table->foreign(['receivable_id'])->references('id')->on('receivables');
 
-            $table->dropForeign('debt_payments_payment_method_id_foreign');
+            $table->dropForeign(['payment_method_id']);
             $table->foreign(['payment_method_id'])->references('id')->on('payment_methods');
 
-            $table->dropForeign('debt_payments_user_id_foreign');
+            $table->dropForeign(['user_id']);
             $table->foreign(['user_id'])->references('id')->on('users');
         });
     }

--- a/database/seeders/CategorySeeder.php
+++ b/database/seeders/CategorySeeder.php
@@ -15,7 +15,9 @@ class CategorySeeder extends Seeder
      */
     public function run()
     {
-        DB::statement('SET FOREIGN_KEY_CHECKS=0');
+        if (DB::getDriverName() !== 'sqlite') {
+            DB::statement('SET FOREIGN_KEY_CHECKS=0');
+        }
         Category::truncate();
         Category::create([
             'name' => "UMUM"


### PR DESCRIPTION
## What’s this PR about?

Modifies the readme to mention .env configuration first as I was having an error if I ran `composer install` first and also modifies some of the seeders and migrations to work in a sqlite environment for local testing/development. 

---

## Changes

- Feature / Fix / Update: `php artisan migrate --path=database/migrations/tenant --seed` will now run if you're using sqlite

---

## Checklist

- [x] Code works as expected
- [x] No breaking changes
- [x] Ready for review

---
