### PR TITLE
fix: product list in cashier by available stock ready

### DIFF
--- a/app/Filament/Tenant/Pages/Traits/CartInteraction.php
+++ b/app/Filament/Tenant/Pages/Traits/CartInteraction.php
@@ -11,7 +11,7 @@ trait CartInteraction
 {
     private function validateStock(Product $product, $qty): bool
     {
-        if (! $product->is_non_stock && ($product->stock < 0 || $product->stock < $qty)) {
+        if (! $product->is_non_stock && ($product->stocks()->sum("stock") < 0 || $product->stocks()->sum("stock") < $qty)) {
             Notification::make()
                 ->title(__('Stock is out'))
                 ->danger()

--- a/app/Filament/Tenant/Pages/Traits/TableProduct.php
+++ b/app/Filament/Tenant/Pages/Traits/TableProduct.php
@@ -79,7 +79,7 @@ trait TableProduct
                         ->extraAttributes([
                             'class' => 'font-bold',
                         ])
-                        ->formatStateUsing(fn (Product $product) => __('Stock').': '.$product->stock),
+                        ->formatStateUsing(fn (Product $product) => __('Stock').': '.$product->stocks()->sum('stock')),
                 ]),
             ])
             ->contentGrid([


### PR DESCRIPTION
## What’s this PR about?

Stock column in product table don't update if increase or decrease of stock pada stocks table.

---

## Changes

- Fix : product list in cashier by available stock ready

---

## Checklist

- [x] Code works as expected
- [x] No breaking changes
- [x] Ready for review

---
