### PR TITLE
feat(settings): added an option for  MXN currency in general settings

### DIFF
--- a/app/Filament/Tenant/Pages/GeneralSetting.php
+++ b/app/Filament/Tenant/Pages/GeneralSetting.php
@@ -108,6 +108,7 @@ class GeneralSetting extends Page implements HasActions, HasForms
                             Select::make('currency')
                                 ->options([
                                     'IDR' => 'IDR',
+                                    'MXN' => 'MXN',
                                     'USD' => 'USD',
                                 ])
                                 ->translateLabel(),


### PR DESCRIPTION
## What’s this PR about?

On this PR I added the MXN currency option to expand the currency options on the aplication (this is the México currency)

---

## Changes

I only added the option to the general settings

---

## Checklist

- [x] Code works as expected
- [x] No breaking changes
- [x] Ready for review

---

## 🧾 Screenshots / Logs (if UI or relevant)

<img width="1220" height="223" alt="image" src="https://github.com/user-attachments/assets/0a5c0472-b3fd-4371-aba3-fa671d26fc85" />

---
