### PR TITLE
fix: use barcode relation lookup in stock flows

### DIFF
--- a/app/Filament/Tenant/Resources/PurchasingResource/Pages/ViewPurchasing.php
+++ b/app/Filament/Tenant/Resources/PurchasingResource/Pages/ViewPurchasing.php
@@ -104,7 +104,7 @@ class ViewPurchasing extends ViewRecord
         }
 
         /** @var Product $product */
-        $product = Product::where('barcode', $barcode)->orWhere('sku', $barcode)->first();
+        $product = Product::findByBarcodeOrSku($barcode);
         if (! $product) {
             Notification::make()
                 ->title(__('Product not found'))

--- a/app/Filament/Tenant/Resources/StockOpnameResource/Pages/ViewStockOpname.php
+++ b/app/Filament/Tenant/Resources/StockOpnameResource/Pages/ViewStockOpname.php
@@ -127,7 +127,7 @@ class ViewStockOpname extends ViewRecord
         }
 
         /** @var Product $product */
-        $product = Product::where('barcode', $barcode)->orWhere('sku', $barcode)->first();
+        $product = Product::findByBarcodeOrSku($barcode);
         if (! $product) {
             Notification::make()
                 ->title(__('Product not found'))


### PR DESCRIPTION
## Summary
- Use Product::findByBarcodeOrSku() when scanning barcodes in purchasing and stock opname flows
- Keep SKU fallback behavior while supporting barcode records stored in the barcodes table

## Related issue
Fixes #345

## Tests
- vendor\\bin\\pest.bat --colors=never --stop-on-failure

Result: 66 passed, 3 skipped (152 assertions)