### PR TITLE
Locale Synchronization & POS Nominal Input Fix

### DIFF
--- a/app/Filament/Tenant/Pages/Cashier.php
+++ b/app/Filament/Tenant/Pages/Cashier.php
@@ -34,6 +34,7 @@ use Illuminate\Support\Collection as CollectionSupport;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationException;
+use App\Models\Tenants\Profile;
 
 class Cashier extends Page implements HasForms, HasTable
 {
@@ -66,6 +67,8 @@ class Cashier extends Page implements HasForms, HasTable
 
     public string $currency;
 
+    public string $locale;
+
     public float $sub_total = 0;
 
     public float $total_price = 0;
@@ -83,6 +86,8 @@ class Cashier extends Page implements HasForms, HasTable
         $this->tax = (float) Setting::get('default_tax', 0);
 
         $this->currency = Setting::get('currency', 'IDR');
+
+        $this->locale = Profile::get()->locale ?? 'en';
 
         $this->cartItems = CartItem::query()
             ->select('*')

--- a/app/Filament/Tenant/Pages/POS.php
+++ b/app/Filament/Tenant/Pages/POS.php
@@ -9,6 +9,7 @@ use App\Models\Tenants\Product;
 use App\Traits\HasTranslatableResource;
 use Filament\Pages\Page;
 use App\Models\Tenants\Setting;
+use App\Models\Tenants\Profile;
 
 class POS extends Page
 {
@@ -33,10 +34,12 @@ class POS extends Page
 
     public $cartItems = [];
     public $currency;
+    public $locale;
 
     public function mount()
     {
         $this->currency = Setting::get('currency', 'IDR');
+        $this->locale = Profile::get()->locale ?? 'en';
         $this->allCategory();
 
         $this->categories = array_merge([

--- a/app/Filament/Tenant/Pages/POS.php
+++ b/app/Filament/Tenant/Pages/POS.php
@@ -8,6 +8,7 @@ use App\Models\Tenants\Category;
 use App\Models\Tenants\Product;
 use App\Traits\HasTranslatableResource;
 use Filament\Pages\Page;
+use App\Models\Tenants\Setting;
 
 class POS extends Page
 {
@@ -31,9 +32,11 @@ class POS extends Page
     public $categories = [];
 
     public $cartItems = [];
+    public $currency;
 
     public function mount()
     {
+        $this->currency = Setting::get('currency', 'IDR');
         $this->allCategory();
 
         $this->categories = array_merge([

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -77,6 +77,7 @@ function padText(text, length, alignRight = false, center = false, textSize = 'n
 
 function moneyFormat(number, currency = null) {
   const activeCurrency = currency || window.lakasirCurrency || 'IDR';
+  const activeLocale = window.lakasirLocale || 'en';
 
   const options = {
     style: 'currency',
@@ -89,7 +90,14 @@ function moneyFormat(number, currency = null) {
     options.minimumFractionDigits = 0;
   }
 
-  const formatter = new Intl.NumberFormat(undefined, options);
+  const formatter = new Intl.NumberFormat(activeLocale, options);
+
+  return formatter.format(number);
+}
+
+function numberFormat(number) {
+  const activeLocale = window.lakasirLocale || 'en';
+  const formatter = new Intl.NumberFormat(activeLocale);
 
   return formatter.format(number);
 }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,5 +1,10 @@
 let selectedDevice = null;
 
+/**
+ * Retrieve printer settings from localStorage.
+ * 
+ * @returns {Object|Error} The printer settings object or an Error if not set.
+ */
 function getPrinter() {
   if (localStorage.printer == undefined) {
     console.error('printer didn\'t set');
@@ -9,6 +14,12 @@ function getPrinter() {
   return JSON.parse(localStorage.printer);
 }
 
+/**
+ * Print text to a USB ESC/POS printer.
+ * 
+ * @param {string} text - The ESC/POS command string to print.
+ * @returns {Promise<void>}
+ */
 async function printToUSBPrinter(text) {
   let receiptText = text;
   console.log(receiptText);
@@ -54,6 +65,16 @@ async function printToUSBPrinter(text) {
   }
 }
 
+/**
+ * Pad text for receipt printing.
+ * 
+ * @param {string} text - The text to pad.
+ * @param {number} length - Target length.
+ * @param {boolean} alignRight - Whether to align right.
+ * @param {boolean} center - Whether to center the text.
+ * @param {string} textSize - Text size ('normal' or 'large').
+ * @returns {string} The padded text.
+ */
 function padText(text, length, alignRight = false, center = false, textSize = 'normal') {
   const sizes = {
     'normal': '\x1D\x21\x00', // Normal text
@@ -75,6 +96,14 @@ function padText(text, length, alignRight = false, center = false, textSize = 'n
   return paddedText;
 }
 
+/**
+ * Formats a number as currency.
+ * For IDR, decimals are hidden for a cleaner POS look.
+ * 
+ * @param {number} number - The value to format.
+ * @param {string|null} currency - Currency code (e.g., 'IDR', 'USD').
+ * @returns {string} The formatted currency string.
+ */
 function moneyFormat(number, currency = null) {
   const activeCurrency = currency || window.lakasirCurrency || 'IDR';
   const activeLocale = window.lakasirLocale || 'en';
@@ -84,8 +113,6 @@ function moneyFormat(number, currency = null) {
     currency: activeCurrency,
   };
 
-  // For IDR, we typically want to hide decimals in a POS context for a cleaner look.
-  // For other currencies (like USD), Intl.NumberFormat will naturally use 2 decimals.
   if (activeCurrency === 'IDR') {
     options.minimumFractionDigits = 0;
   }
@@ -95,6 +122,12 @@ function moneyFormat(number, currency = null) {
   return formatter.format(number);
 }
 
+/**
+ * Formats a number using the active locale.
+ * 
+ * @param {number} number - The value to format.
+ * @returns {string} The formatted number string.
+ */
 function numberFormat(number) {
   const activeLocale = window.lakasirLocale || 'en';
   const formatter = new Intl.NumberFormat(activeLocale);

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -76,10 +76,20 @@ function padText(text, length, alignRight = false, center = false, textSize = 'n
 }
 
 function moneyFormat(number, currency = null) {
-  const formatter = new Intl.NumberFormat({
+  const activeCurrency = currency || window.lakasirCurrency || 'IDR';
+
+  const options = {
     style: 'currency',
-    currency: currency,
-  });
+    currency: activeCurrency,
+  };
+
+  // For IDR, we typically want to hide decimals in a POS context for a cleaner look.
+  // For other currencies (like USD), Intl.NumberFormat will naturally use 2 decimals.
+  if (activeCurrency === 'IDR') {
+    options.minimumFractionDigits = 0;
+  }
+
+  const formatter = new Intl.NumberFormat(undefined, options);
 
   return formatter.format(number);
 }

--- a/resources/views/filament/tenant/pages/cashier.blade.php
+++ b/resources/views/filament/tenant/pages/cashier.blade.php
@@ -451,6 +451,7 @@
 @script()
   <script>
     window.lakasirCurrency = @js($currency);
+    window.lakasirLocale = @js($locale);
     let selling = null;
     $wire.on('selling-created', (event) => {
       selling = event.selling;
@@ -668,7 +669,7 @@
 
       for (let suggestion of shortcutSuggestion) {
         const button = document.createElement('button');
-        button.textContent = moneyFormat(suggestion);
+        button.textContent = numberFormat(suggestion);
         button.setAttribute('type', 'button')
         button.setAttribute('x-on:click', `shortcut(${suggestion})`);
         button.className = 'bg-gray-300 hover:bg-gray-400 p-2 rounded-md text-lg';

--- a/resources/views/filament/tenant/pages/cashier.blade.php
+++ b/resources/views/filament/tenant/pages/cashier.blade.php
@@ -450,6 +450,7 @@
 
 @script()
   <script>
+    window.lakasirCurrency = @js($currency);
     let selling = null;
     $wire.on('selling-created', (event) => {
       selling = event.selling;
@@ -607,11 +608,21 @@
           this.changes();
         },
         changes() {
-          let num = parseFloat(this.$refs.payedMoney.value.replace(/,/g, ''));
+          let val = this.$refs.payedMoney.value || '';
+          // Remove everything except digits to handle various locale formatting (thousands separators, currency symbols)
+          let numericValue = val.replace(/\D/g, '');
+          let num = parseInt(numericValue, 10);
           num = isNaN(num) ? 0 : num;
+
+          // Sync back the raw numeric value to displayValue so subsequent button presses work correctly
+          this.displayValue = num > 0 ? num.toString() : '';
+
           $wire.cartDetail['money_changes'] = num - (this.subtotal);
           $wire.cartDetail['payed_money'] = num;
-          this.$refs.moneyChanges.textContent = moneyFormat($wire.cartDetail['money_changes']);
+
+          if (this.$refs.moneyChanges) {
+            this.$refs.moneyChanges.textContent = moneyFormat($wire.cartDetail['money_changes']);
+          }
         }
       }
     });

--- a/resources/views/filament/tenant/pages/cashier.blade.php
+++ b/resources/views/filament/tenant/pages/cashier.blade.php
@@ -608,10 +608,6 @@
           this.$refs.payedMoney.value = moneyFormat(this.displayValue);
           this.changes();
         },
-        /**
-         * Calculate changes and update payment values.
-         * Removes non-digits for locale formatting and syncs raw value to displayValue.
-         */
         changes() {
           let val = this.$refs.payedMoney.value || '';
           let numericValue = val.replace(/\D/g, '');

--- a/resources/views/filament/tenant/pages/cashier.blade.php
+++ b/resources/views/filament/tenant/pages/cashier.blade.php
@@ -608,14 +608,16 @@
           this.$refs.payedMoney.value = moneyFormat(this.displayValue);
           this.changes();
         },
+        /**
+         * Calculate changes and update payment values.
+         * Removes non-digits for locale formatting and syncs raw value to displayValue.
+         */
         changes() {
           let val = this.$refs.payedMoney.value || '';
-          // Remove everything except digits to handle various locale formatting (thousands separators, currency symbols)
           let numericValue = val.replace(/\D/g, '');
           let num = parseInt(numericValue, 10);
           num = isNaN(num) ? 0 : num;
 
-          // Sync back the raw numeric value to displayValue so subsequent button presses work correctly
           this.displayValue = num > 0 ? num.toString() : '';
 
           $wire.cartDetail['money_changes'] = num - (this.subtotal);

--- a/resources/views/filament/tenant/pages/pos/index.blade.php
+++ b/resources/views/filament/tenant/pages/pos/index.blade.php
@@ -162,6 +162,7 @@
 @script()
 <script>
   window.lakasirCurrency = @js($currency);
+  window.lakasirLocale = @js($locale);
   Alpine.data('pos', () => {
     return {
       items: @json($menuItems),

--- a/resources/views/filament/tenant/pages/pos/index.blade.php
+++ b/resources/views/filament/tenant/pages/pos/index.blade.php
@@ -161,6 +161,7 @@
 
 @script()
 <script>
+  window.lakasirCurrency = @js($currency);
   Alpine.data('pos', () => {
     return {
       items: @json($menuItems),


### PR DESCRIPTION
## Description

This PR fixes nominal input parsing issues on mobile browsers (specifically Chrome Android) and implements locale and currency synchronization between server and client for UI consistency.

### Main Changes:

#### 1. Backend (Laravel/Filament)

- **`app/Filament/Tenant/Pages/Cashier.php` & `POS.php`**:
    - Added `$locale` and `$currency` properties.
    - Fetches user locale from `Profile::get()->locale` to match the user's language preference in the system.
    - Fetches currency from `Setting::get('currency')`.

#### 2. Frontend Logic (`resources/js/app.js`)

- **`moneyFormat`**: Updated to use `window.lakasirLocale` and `window.lakasirCurrency`. Now correctly uses the `Intl.NumberFormat` API.
- **`numberFormat`**: Added a new helper to format numbers (thousands) without a currency symbol, used specifically for shortcut buttons for a cleaner UI.
- **Precision Logic**: Added special handling for `IDR` to hide decimal places (0 digits), while still supporting standard decimals for other international currencies.

#### 3. Blade Views (`cashier.blade.php` & `pos/index.blade.php`)

- **JS Context Injection**: Injects `$locale` and `$currency` variables into global JavaScript.
- **Robust Parsing**: Updated `changes()` logic to strip non-digit characters (`/\D/g`) before parsing. This fixes a bug where the thousands format `10.000` (ID locale) was being read as `10` by JavaScript.
- **State Sync**: Automatic synchronization between `displayValue` and the nominal input to keep keyboard input and on-screen buttons in sync.
- **Clean UI Shortcut**: Updated payment suggestion buttons to use `numberFormat` (removing the IDR/Rp prefix as requested).

## Proof of Changes

- Nominal input on Android Chrome now parses correctly even when using dots as thousands separators.
- Currency formatting across all POS pages is now consistent with the user's language preference in their profile.
- Shortcut buttons (20k, 50k, etc.) now display formatted numbers only, without a currency symbol.

## Checklist

- [x] PHP → JS locale synchronization works.
- [x] Number parsing correctly ignores currency symbols and thousands separators.
- [x] Shortcut buttons display without currency prefix.
- [x] Decimal compatibility for non-IDR currencies is maintained.

<img width="904" height="1599" alt="WhatsApp Image 2026-05-10 at 17 11 00" src="https://github.com/user-attachments/assets/64180651-cad2-45e1-a2c1-35349ce2d6c6" />

<img width="846" height="1600" alt="WhatsApp Image 2026-05-10 at 17 11 00 (1)" src="https://github.com/user-attachments/assets/e4d36a0f-f622-4f77-a1ac-920b25beb7d5" />
