### PR TITLE
feat: barcode & product import improvements

### DIFF
--- a/app/Http/Controllers/Api/Tenants/Master/ProductController.php
+++ b/app/Http/Controllers/Api/Tenants/Master/ProductController.php
@@ -29,7 +29,7 @@ class ProductController extends Controller
                 'unit',
                 'show',
                 ...ComparisonFilter::setFilters('stock', ['gt', 'ge', 'lt', 'le', 'eq', 'ne']),
-                AllowedFilter::custom('global', new SearchFields, 'name,sku,barcode'),
+                AllowedFilter::custom('global', new SearchFields, 'name,sku,barcodes.code'),
             ])
             ->allowedIncludes(['category', 'images'])
             ->orderByDesc('created_at')

--- a/app/Http/Requests/Tenants/Master/ProductRequest.php
+++ b/app/Http/Requests/Tenants/Master/ProductRequest.php
@@ -8,6 +8,7 @@ use App\Models\Tenants\Category;
 use App\Models\Tenants\Product;
 use App\Models\Tenants\ProductImage;
 use App\Models\Tenants\UploadedFile;
+use App\Models\Tenants\Barcode;
 use App\Services\Tenants\ProductService;
 use Exception;
 use Illuminate\Foundation\Http\FormRequest;
@@ -58,7 +59,18 @@ class ProductRequest extends FormRequest
 
         return [
             'sku' => [Rule::unique(Product::class)->ignore($this->route('product'))],
-            'barcode' => ['nullable', 'min:3', Rule::unique(Product::class)->ignore($this->route('product'))],
+            'barcode' => ['nullable', 'min:3', function ($attribute, $value, $fail) {
+                if ($value) {
+                    $query = Barcode::where('code', $value);
+                    if ($this->method() == 'PUT') {
+                        $product = Product::findorfail($this->route('product'));
+                        $query->where('product_id', '!=', $product->id);
+                    }
+                    if ($query->exists()) {
+                        $fail('The barcode has already been taken.');
+                    }
+                }
+            }],
             'name' => ['required', 'min:3'],
             'category' => ['required'],
             'stock' => ['numeric', Rule::requiredIf(! $this->is_non_stock)],

--- a/app/Http/Requests/Tenants/Master/ProductRequest.php
+++ b/app/Http/Requests/Tenants/Master/ProductRequest.php
@@ -98,6 +98,7 @@ class ProductRequest extends FormRequest
             $product = new Product();
             $product->fill($this->merging());
             $product->save();
+            $this->syncPrimaryBarcode($product);
             $this->uploadImage($product);
             DB::commit();
         } catch (Exception $e) {
@@ -113,6 +114,7 @@ class ProductRequest extends FormRequest
             $product = Product::findorfail($this->route('product'));
             $product->fill($this->merging());
             $product->update();
+            $this->syncPrimaryBarcode($product);
             $this->uploadImage($product);
             DB::commit();
         } catch (Exception $e) {
@@ -125,7 +127,38 @@ class ProductRequest extends FormRequest
     {
         return $this->merge([
             'category_id' => Category::findorfail($this->category)->id,
-        ])->except('category', 'images');
+        ])->except('category', 'images', 'barcode');
+    }
+
+    private function syncPrimaryBarcode(Product $product): void
+    {
+        if (! $this->filled('barcode')) {
+            return;
+        }
+
+        $barcodeCode = $this->barcode;
+        $product->barcodes()
+            ->primary()
+            ->active()
+            ->where('code', '!=', $barcodeCode)
+            ->update(['is_active' => false]);
+
+        $barcode = $product->barcodes()->where('code', $barcodeCode)->first();
+        if ($barcode) {
+            $barcode->update([
+                'type' => 'primary',
+                'is_active' => true,
+            ]);
+
+            return;
+        }
+
+        $product->barcodes()->create([
+            'code' => $barcodeCode,
+            'type' => 'primary',
+            'description' => 'API barcode',
+            'is_active' => true,
+        ]);
     }
 
     private function images(): ?array

--- a/app/Imports/ProductImport.php
+++ b/app/Imports/ProductImport.php
@@ -14,26 +14,56 @@ class ProductImport implements SkipsEmptyRows, ToModel, WithHeadingRow
 {
     public function model(array $row)
     {
-        $category = Category::query()->updateOrCreate(
-            [
-                'name' => $row['category'],
-            ],
-            [
-                'name' => $row['category'],
-            ],
+        // WithHeadingRow converts blank headers to numeric keys (1, 2, etc.)
+        // The Excel template's column B has a blank header for "name",
+        // so it becomes key "1" instead of "name".
+        // Map it properly:
+        if (isset($row['name'])) {
+            $name = $row['name'];
+        } elseif (isset($row[1])) {
+            // Column B (index 1 after heading row conversion) is the "name" column
+            $name = $row[1];
+            unset($row[1]);
+        } else {
+            return null; // Skip rows without a name
+        }
+
+        // Skip rows without a name value
+        if (empty($name)) {
+            return null;
+        }
+
+        $row['name'] = $name;
+
+        // Use updateOrCreate to avoid duplicate products on re-import
+        $category = Category::query()->firstOrCreate(
+            ['name' => $row['category'] ?? 'Uncategorized'],
+            ['name' => $row['category'] ?? 'Uncategorized'],
         );
 
         /** @var Product $product */
         $product = Product::create([
             'name' => $row['name'],
             'category_id' => $category->id,
-            'unit' => $row['unit'],
-            'barcode' => (int) $row['barcode'],
-            'stock' => (int) $row['stock'],
+            'unit' => $row['unit'] ?? null,
+            'sku' => $row['sku'] ?? null,
+            'stock' => (int) ($row['stock'] ?? 0),
             'initial_price' => $row['initial_price'] ?? 0,
             'selling_price' => $row['selling_price'] ?? 0,
-            'type' => $row['type'] ?? 'product',
+            'type' => !empty($row['type']) ? $row['type'] : 'product',
         ]);
+
+        // Create barcode record if barcode value exists and is not a duplicate
+        if (!empty($row['barcode'])) {
+            $barcodeStr = (string) $row['barcode'];
+            if (!\App\Models\Tenants\Barcode::where('code', $barcodeStr)->exists()) {
+                $product->barcodes()->create([
+                    'code' => $barcodeStr,
+                    'type' => 'primary',
+                    'is_active' => true,
+                ]);
+            }
+        }
 
         if (isset($row['other_price']) && $row['other_price'] != null && $row['other_price'] != '') {
             $dataOtherPrice = Str::of($row['other_price'])->explode(',');

--- a/app/Imports/ProductImport.php
+++ b/app/Imports/ProductImport.php
@@ -36,7 +36,7 @@ class ProductImport implements SkipsEmptyRows, ToModel, WithHeadingRow
 
         $row['name'] = $name;
 
-        // Use updateOrCreate to avoid duplicate products on re-import
+        // Ensure import category exists before product creation.
         $category = Category::query()->firstOrCreate(
             ['name' => $row['category'] ?? 'Uncategorized'],
             ['name' => $row['category'] ?? 'Uncategorized'],

--- a/app/Imports/ProductImport.php
+++ b/app/Imports/ProductImport.php
@@ -5,6 +5,7 @@ namespace App\Imports;
 use App\Models\Tenants\Category;
 use App\Models\Tenants\PriceUnit;
 use App\Models\Tenants\Product;
+use App\Observers\ProductObserver;
 use Illuminate\Support\Str;
 use Maatwebsite\Excel\Concerns\SkipsEmptyRows;
 use Maatwebsite\Excel\Concerns\ToModel;
@@ -41,6 +42,12 @@ class ProductImport implements SkipsEmptyRows, ToModel, WithHeadingRow
             ['name' => $row['category'] ?? 'Uncategorized'],
         );
 
+        if (!empty($row['barcode'])) {
+            ProductObserver::setTempBarcodesData([
+                ['code' => $row['barcode'], 'type' => 'primary', 'is_active' => true]
+            ]);
+        }
+
         /** @var Product $product */
         $product = Product::create([
             'name' => $row['name'],
@@ -53,16 +60,13 @@ class ProductImport implements SkipsEmptyRows, ToModel, WithHeadingRow
             'type' => !empty($row['type']) ? $row['type'] : 'product',
         ]);
 
-        // Create barcode record if barcode value exists and is not a duplicate
         if (!empty($row['barcode'])) {
-            $barcodeStr = (string) $row['barcode'];
-            if (!\App\Models\Tenants\Barcode::where('code', $barcodeStr)->exists()) {
-                $product->barcodes()->create([
-                    'code' => $barcodeStr,
-                    'type' => 'primary',
-                    'is_active' => true,
-                ]);
-            }
+            $product->barcodes()->create([
+                'code' => $row['barcode'],
+                'type' => 'primary',
+                'description' => 'Imported barcode',
+                'is_active' => true,
+            ]);
         }
 
         if (isset($row['other_price']) && $row['other_price'] != null && $row['other_price'] != '') {

--- a/app/Observers/ProductObserver.php
+++ b/app/Observers/ProductObserver.php
@@ -31,14 +31,14 @@ class ProductObserver extends AbstractObserver implements DataAwareRule
     {
         $prefix = Str::of($product->category->name)->substr(0, 3)->upper();
 
-        return $prefix.'-'.Str::of($product->name)->substr(0, 3)->upper().'-'.Str::of($product->id)->padLeft(4, 0)->value();
+        return $prefix . '-' . Str::of($product->name)->substr(0, 3)->upper() . '-' . Str::of($product->id)->padLeft(4, 0)->value();
     }
 
     private function generateBarcode(Product $product): string
     {
         $prefix = Str::of($product->category->name)->substr(0, 3)->upper();
 
-        return $prefix.'-'.Str::of($product->name)->substr(0, 3)->upper().'-'.Str::of($product->id)->padLeft(4, 0)->value();
+        return $prefix . '-' . Str::of($product->name)->substr(0, 3)->upper() . '-' . Str::of($product->id)->padLeft(4, 0)->value();
     }
 
     public function creating(Product $product): void
@@ -62,8 +62,8 @@ class ProductObserver extends AbstractObserver implements DataAwareRule
 
 
         $hasFormBarcodes = !empty(self::$tempBarcodesData) &&
-                          is_array(self::$tempBarcodesData) &&
-                          !empty(array_filter(self::$tempBarcodesData, fn($barcode) => !empty($barcode['code'])));
+            is_array(self::$tempBarcodesData) &&
+            !empty(array_filter(self::$tempBarcodesData, fn($barcode) => !empty($barcode['code'])));
 
 
         if (! $hasFormBarcodes) {

--- a/tests/Feature/Http/Controllers/Api/Tenants/Master/ProductControllerTest.php
+++ b/tests/Feature/Http/Controllers/Api/Tenants/Master/ProductControllerTest.php
@@ -97,3 +97,30 @@ test('update persists changed barcode to barcode relation', function () {
     $product->refresh();
     expect($product->barcodes()->primary()->active()->value('code'))->toBe('API-BAR-UPDATED');
 });
+
+test('can filter products globally by barcode code', function () {
+    $user = User::first();
+    $category = Category::factory()->create();
+
+    $productWithBarcode = Product::factory()->create([
+        'category_id' => $category->id,
+        'name' => 'Product With Searchable Barcode',
+    ]);
+    $productWithBarcode->barcodes()->create([
+        'code' => 'FILTER-BARCODE-001',
+        'type' => 'primary',
+        'description' => 'Test barcode',
+        'is_active' => true,
+    ]);
+
+    Product::factory()->create([
+        'category_id' => $category->id,
+        'name' => 'Another Product',
+    ]);
+
+    actingAs($user, 'sanctum')
+        ->getJson('/api/master/product?filter[global]=FILTER-BARCODE-001')
+        ->assertOk()
+        ->assertJsonCount(1, 'data.data')
+        ->assertJsonPath('data.data.0.id', $productWithBarcode->id);
+});

--- a/tests/Feature/Http/Controllers/Api/Tenants/Master/ProductControllerTest.php
+++ b/tests/Feature/Http/Controllers/Api/Tenants/Master/ProductControllerTest.php
@@ -57,3 +57,43 @@ test('can clamp per_page to maximum of 100', function () {
         ->assertJsonPath('data.meta.per_page', 100)
         ->assertJsonCount(20, 'data.data');
 });
+
+test('store persists barcode to barcode relation', function () {
+    $user = User::first();
+    $category = Category::factory()->create();
+
+    actingAs($user, 'sanctum')
+        ->postJson('/api/master/product', [
+            'name' => 'Barcode API Product',
+            'sku' => 'SKU-BARCODE-001',
+            'barcode' => 'API-BAR-001',
+            'category' => $category->id,
+            'stock' => 10,
+            'initial_price' => 10000,
+            'selling_price' => 15000,
+            'type' => 'product',
+            'is_non_stock' => false,
+            'expired' => now()->addDay()->toDateString(),
+        ])
+        ->assertOk();
+
+    $product = Product::query()->where('name', 'Barcode API Product')->firstOrFail();
+    expect($product->barcodes()->primary()->active()->value('code'))->toBe('API-BAR-001');
+});
+
+test('update persists changed barcode to barcode relation', function () {
+    $user = User::first();
+    $category = Category::factory()->create();
+    $product = Product::factory()->create([
+        'category_id' => $category->id,
+    ]);
+
+    actingAs($user, 'sanctum')
+        ->putJson("/api/master/product/{$product->id}", [
+            'barcode' => 'API-BAR-UPDATED',
+        ])
+        ->assertOk();
+
+    $product->refresh();
+    expect($product->barcodes()->primary()->active()->value('code'))->toBe('API-BAR-UPDATED');
+});

--- a/tests/Unit/Imports/ProductImportTest.php
+++ b/tests/Unit/Imports/ProductImportTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use App\Imports\ProductImport;
+use App\Models\Tenants\Barcode;
+use App\Models\Tenants\Category;
+use App\Models\Tenants\Product;
+use Tests\RefreshDatabaseWithTenant;
+
+uses(RefreshDatabaseWithTenant::class);
+
+beforeEach(function () {
+    Category::factory()->create(['name' => 'Uncategorized']);
+});
+
+describe('ProductImport barcode handling', function () {
+    test('import with barcode creates exactly 1 barcode with correct code', function () {
+        $import = new ProductImport();
+        $product = $import->model([
+            'name' => 'Test Product',
+            'barcode' => 'IMP-001',
+            'category' => 'Uncategorized',
+            'unit' => 'pcs',
+            'stock' => 10,
+            'initial_price' => 10000,
+            'selling_price' => 15000,
+            'type' => 'product',
+        ]);
+
+        expect($product)->toBeInstanceOf(Product::class);
+
+        $barcodes = $product->barcodes()->get();
+        expect($barcodes)->toHaveCount(1);
+        expect($barcodes->first()->code)->toBe('IMP-001');
+        expect($barcodes->first()->type)->toBe('primary');
+        expect($barcodes->first()->is_active)->toBeTrue();
+    });
+
+    test('import without barcode auto-generates one barcode', function () {
+        $import = new ProductImport();
+        $product = $import->model([
+            'name' => 'Test Product',
+            'category' => 'Uncategorized',
+            'unit' => 'pcs',
+            'stock' => 10,
+            'initial_price' => 10000,
+            'selling_price' => 15000,
+            'type' => 'product',
+        ]);
+
+        expect($product)->toBeInstanceOf(Product::class);
+
+        $barcodes = $product->barcodes()->get();
+        expect($barcodes)->toHaveCount(1);
+        expect($barcodes->first()->type)->toBe('primary');
+    });
+
+    test('import with empty barcode string still auto-generates one barcode', function () {
+        $import = new ProductImport();
+        $product = $import->model([
+            'name' => 'Test Product',
+            'barcode' => '',
+            'category' => 'Uncategorized',
+            'unit' => 'pcs',
+            'stock' => 10,
+            'initial_price' => 10000,
+            'selling_price' => 15000,
+            'type' => 'product',
+        ]);
+
+        expect($product)->toBeInstanceOf(Product::class);
+
+        $barcodes = $product->barcodes()->get();
+        expect($barcodes)->toHaveCount(1);
+        expect($barcodes->first()->type)->toBe('primary');
+    });
+});


### PR DESCRIPTION
This pull request introduces several important improvements to product import, barcode validation, and filtering logic. The main changes enhance data integrity for barcodes, improve Excel import reliability, and refine product search capabilities.

---

## Changes

- Search products by barcode via barcodes.code relation
- Validate barcode uniqueness against Barcode model instead of Product
- Improve product import: handle blank headers, skip empty rows,
  create barcode records, use firstOrCreate for categories
- Trust all proxies for reverse proxy setups## What’s this PR about?

---

## Checklist

- [x] Code works as expected
- [x] No breaking changes
- [x] Ready for review
