### PR TITLE
Auto-sync version.txt from latest Git tag with new command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ _ide_helper.php
 tasks/
 .mcp.json
 opencode.json
+version.txt

--- a/app/Console/Commands/VersionSyncCommand.php
+++ b/app/Console/Commands/VersionSyncCommand.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class VersionSyncCommand extends Command
+{
+    protected $signature = 'app:version-sync';
+
+    protected $description = 'Sync version.txt with the latest git tag';
+
+    public function handle(): void
+    {
+        $tag = trim(shell_exec('git describe --tags --abbrev=0 2>/dev/null') ?? '');
+
+        $version = $tag ?: 'Development';
+
+        file_put_contents(base_path('version.txt'), $version);
+
+        $this->info("version.txt synced to: {$version}");
+    }
+}

--- a/app/Console/Commands/VersionSyncCommand.php
+++ b/app/Console/Commands/VersionSyncCommand.php
@@ -13,11 +13,23 @@ class VersionSyncCommand extends Command
     public function handle(): void
     {
         $tag = trim(shell_exec('git describe --tags --abbrev=0 2>/dev/null') ?? '');
+        $hasGitMetadata = is_dir(base_path('.git'));
 
-        $version = $tag ?: 'Development';
+        if ($tag !== '') {
+            file_put_contents(base_path('version.txt'), $tag);
+            $this->info("version.txt synced to: {$tag}");
 
-        file_put_contents(base_path('version.txt'), $version);
+            return;
+        }
 
-        $this->info("version.txt synced to: {$version}");
+        if ($hasGitMetadata) {
+            $version = 'Development';
+            file_put_contents(base_path('version.txt'), $version);
+            $this->info("version.txt synced to: {$version}");
+
+            return;
+        }
+
+        $this->warn('Git metadata is unavailable; leaving existing version.txt untouched.');
     }
 }

--- a/app/Console/Commands/VersionSyncCommand.php
+++ b/app/Console/Commands/VersionSyncCommand.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands;
 
 use Illuminate\Console\Command;
+use Symfony\Component\Process\Process;
 
 class VersionSyncCommand extends Command
 {
@@ -10,26 +11,43 @@ class VersionSyncCommand extends Command
 
     protected $description = 'Sync version.txt with the latest git tag';
 
-    public function handle(): void
+    public function handle(): int
     {
-        $tag = trim(shell_exec('git describe --tags --abbrev=0 2>/dev/null') ?? '');
         $hasGitMetadata = is_dir(base_path('.git'));
+
+        if (! $hasGitMetadata) {
+            $this->warn('Git metadata is unavailable; leaving existing version.txt untouched.');
+
+            return Command::SUCCESS;
+        }
+
+        $process = new Process(['git', 'describe', '--tags', '--abbrev=0']);
+        $process->setWorkingDirectory(base_path());
+        $process->run();
+
+        $tag = trim($process->getOutput());
 
         if ($tag !== '') {
             file_put_contents(base_path('version.txt'), $tag);
             $this->info("version.txt synced to: {$tag}");
 
-            return;
+            return Command::SUCCESS;
         }
 
-        if ($hasGitMetadata) {
-            $version = 'Development';
-            file_put_contents(base_path('version.txt'), $version);
-            $this->info("version.txt synced to: {$version}");
+        if (! $process->isSuccessful()) {
+            $errorOutput = strtolower(trim($process->getErrorOutput()));
 
-            return;
+            if (! str_contains($errorOutput, 'no names found')) {
+                $this->error('Failed to resolve the latest Git tag.');
+
+                return Command::FAILURE;
+            }
         }
 
-        $this->warn('Git metadata is unavailable; leaving existing version.txt untouched.');
+        $version = 'Development';
+        file_put_contents(base_path('version.txt'), $version);
+        $this->info("version.txt synced to: {$version}");
+
+        return Command::SUCCESS;
     }
 }

--- a/app/Services/AppUpdateService.php
+++ b/app/Services/AppUpdateService.php
@@ -44,7 +44,7 @@ class AppUpdateService
         $log = fn ($text) => $logger ? $logger($text) : info($text);
 
         $log('🔍 Checking for updates...');
-        $currentVersion = trim(file_get_contents(base_path('version.txt')));
+        $currentVersion = app(UpdateChecker::class)->getCurrentVersion();
 
         $response = Http::get($this->url);
 

--- a/app/Services/UpdateChecker.php
+++ b/app/Services/UpdateChecker.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
 
 class UpdateChecker
@@ -15,7 +16,15 @@ class UpdateChecker
 
     public function getCurrentVersion(): string
     {
-        return trim(file_get_contents(base_path('version.txt')));
+        $versionPath = base_path('version.txt');
+
+        if (! File::exists($versionPath)) {
+            return 'Development';
+        }
+
+        $version = trim((string) File::get($versionPath));
+
+        return $version !== '' ? $version : 'Development';
     }
 
     private function fetchAndCacheApiResponse(): ?array

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,8 @@
         "post-autoload-dump": [
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
             "@php artisan package:discover --ansi",
-            "@php artisan filament:upgrade"
+            "@php artisan filament:upgrade",
+            "@php artisan app:version-sync"
         ],
         "post-update-cmd": [
             "@php artisan vendor:publish --tag=laravel-assets --ansi --force"

--- a/tests/Unit/Services/UpdateCheckerTest.php
+++ b/tests/Unit/Services/UpdateCheckerTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use App\Services\UpdateChecker;
+use Illuminate\Support\Facades\File;
+
+beforeEach(function () {
+    $this->versionPath = base_path('version.txt');
+    $this->hasOriginalVersionFile = File::exists($this->versionPath);
+    $this->originalVersionContent = $this->hasOriginalVersionFile ? File::get($this->versionPath) : null;
+});
+
+afterEach(function () {
+    if ($this->hasOriginalVersionFile) {
+        File::put($this->versionPath, (string) $this->originalVersionContent);
+
+        return;
+    }
+
+    if (File::exists($this->versionPath)) {
+        File::delete($this->versionPath);
+    }
+});
+
+test('it returns Development when version file does not exist', function () {
+    if (File::exists($this->versionPath)) {
+        File::delete($this->versionPath);
+    }
+
+    $checker = new UpdateChecker();
+
+    expect($checker->getCurrentVersion())->toBe('Development');
+});
+
+test('it returns Development when version file is empty', function () {
+    File::put($this->versionPath, '   ');
+
+    $checker = new UpdateChecker();
+
+    expect($checker->getCurrentVersion())->toBe('Development');
+});
+
+test('it returns trimmed version from version file', function () {
+    File::put($this->versionPath, " 1.2.3 \n");
+
+    $checker = new UpdateChecker();
+
+    expect($checker->getCurrentVersion())->toBe('1.2.3');
+});

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,0 @@
-Development


### PR DESCRIPTION
## What’s this PR about?

This pull request introduces a new command to automatically synchronize the `version.txt` file with the latest Git tag and integrates this process into the Composer workflow. The main goal is to ensure that the application's version information stays up-to-date with Git tags without manual intervention.

## Changes

- Add VersionSyncCommand artisan command (app:version-sync)
- Wire into composer post-autoload-dump for automatic sync
- Add version.txt to .gitignore (now auto-generated)
- Falls back to 'Development' when no tags exist

---

## Checklist

- [x] Code works as expected
- [x] No breaking changes
- [x] Ready for review