### PR TITLE
Fix Barcode Search Query and Enable Controlled Product Pagination 

### DIFF
--- a/app/Filament/Tenant/Pages/Traits/TableProduct.php
+++ b/app/Filament/Tenant/Pages/Traits/TableProduct.php
@@ -41,9 +41,9 @@ trait TableProduct
                     })
                     ->where('show', true)
                     // ->orWhere('type', 'service')
-                    ->limit(12)
             )
-            ->paginated(false)
+            ->defaultPaginationPageOption(12)
+            ->paginationPageOptions([12])
             ->columns([
                 Stack::make([
                     ImageColumn::make('hero_image')
@@ -62,7 +62,14 @@ trait TableProduct
                         ->columnStart(0),
                     TextColumn::make('name')
                         ->size('lg')
-                        ->searchable(['sku', 'name', 'barcode'])
+                        ->searchable(query: function ($query, string $search): void {
+                            $query->where('sku', 'like', "%{$search}%")
+                                ->orWhere('name', 'like', "%{$search}%")
+                                ->orWhereHas('barcodes', function ($query) use ($search) {
+                                    $query->where('code', 'like', "%{$search}%")
+                                        ->where('is_active', true);
+                                });
+                        })
                         ->extraAttributes([
                             'class' => 'font-bold',
                         ]),


### PR DESCRIPTION
## Description
This pull request addresses two critical issues in the Point of Sale (POS) / Cashier catalog table:
1. An SQL exception (`Column not found: 1054 Unknown column 'barcode'`) triggered during product searches.
2. Newly created products not appearing on the Cashier's screen due to a hardcoded query limit.

---

## Changes

### 1. Fix Barcode Search Query
* **File:** [TableProduct.php](file:///home/dani/lakasir/app/Filament/Tenant/Pages/Traits/TableProduct.php#L65-L72)
* **Issue:** The `products` table no longer contains a direct `barcode` column (it was refactored into a separate `barcodes` table with a `hasMany` relationship). Searching for barcode values directly on the `products` table was causing an SQL query error when the system attempted to resolve `where barcode like ...`.
* **Solution:** Replaced the direct `'barcode'` column search in `->searchable()` with a custom query callback. It uses `orWhereHas('barcodes')` to query the code inside the related `barcodes` table, keeping the behavior correct and error-free.

### 2. Enable Controlled Product Pagination (12 Items Per Page)
* **File:** [TableProduct.php](file:///home/dani/lakasir/app/Filament/Tenant/Pages/Traits/TableProduct.php#L43-L46)
* **Issue:** The query had a hardcoded `->limit(12)` constraint, and pagination was disabled via `->paginated(false)`. This meant that once the store had more than 12 products, any products indexed after the 12th item (such as newly added products with IDs 13, 14, 15, and 16) would never show up in the default Cashier view unless specifically searched.
* **Solution:** Removed the hardcoded query limit and enabled Filament's built-in pagination, set to exactly **12 items per page** (`->defaultPaginationPageOption(12)`) and locked to this size option (`->paginationPageOptions([12])`).

---

## Why Pagination is Enabled & Locked to 12

### The Problem with the Old Design
The layout was originally designed for a strict grid system (3 columns on medium screens and 4 columns on extra-large screens) displaying a max of 12 items. However, disabling pagination entirely and setting a database `limit(12)` is a fragile constraint because:
1. It hides all newer products beyond the first 12 matches.
2. It breaks the Cashier's ability to browse products naturally.

### Why 12 is the Optimal Solution
Instead of disabling pagination, we enabled it but **locked the records-per-page options strictly to `12`**:
* **Preserves POS Grid Integrity:** By specifying `->paginationPageOptions([12])`, the cashier cannot change the page size dropdown to `10`, `25`, or `50`, which would otherwise break the layout and overflow the screen.
* **Solves Product Visibility:** The cashier can now browse all products by using the page controls (Previous/Next) at the bottom, ensuring that newly added products are fully accessible.
* **Maintains Performance:** Large catalogs are loaded incrementally (12 at a time), which avoids performance bottlenecks or loading delays on slower client devices.

---

## Verification Plan

### Manual Verification
1. Open the Cashier (POS) page as a non-admin role (e.g., cashier).
2. Verify that the grid displays 12 items and shows pagination controls at the bottom.
3. Click "Next" to verify that products beyond index 12 (IDs 13, 14, 15, 16, etc.) load correctly.
4. Try searching using:
   * A product name (e.g., `Teh Pucuk`)
   * An SKU (e.g., `MIN-TEH-0014`)
   * A barcode code (via the search bar or scanning)
5. Verify that searching does not trigger SQL errors.
