### PR TITLE
fix(docs): update star history chart to working domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,10 @@ For any inquiries or support, please contact lakasirapp@gmail.com or you can ope
 
 ## Star History
 
-<a href="https://star-history.com/#lakasir/lakasir&Date">
+<a href="https://star-history.dera.page/#lakasir/lakasir&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=lakasir/lakasir&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=lakasir/lakasir&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=lakasir/lakasir&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=lakasir/lakasir&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=lakasir/lakasir&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=lakasir/lakasir&type=Date" />
  </picture>
 </a>


### PR DESCRIPTION
The star history chart in the README is currently broken because the underlying GitHub stargazer API is restricted. This change points the chart to a working alternative so the chart renders correctly again.