### PR TITLE
Upgrade Picqer barcode generator to v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "livewire/livewire": "^3.0",
         "livewire/volt": "^1.6",
         "maatwebsite/excel": "^3.1",
-        "picqer/php-barcode-generator": "^2.4",
+        "picqer/php-barcode-generator": "^3.2",
         "predis/predis": "^2.2",
         "sheenazien8/konstantiq": "^1.0",
         "silviolleite/laravelpwa": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7d21c699fc8301e3a034a062f8bfdfad",
+    "content-hash": "3e1c5a7565ff7592c595fe4ad157e01d",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -6562,21 +6562,20 @@
         },
         {
             "name": "picqer/php-barcode-generator",
-            "version": "v2.4.2",
+            "version": "v3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/picqer/php-barcode-generator.git",
-                "reference": "e9d39681f617705492b609fc3fc58465ef88e8fd"
+                "reference": "6beada2a30623832ff41b8c7d307c169736b8552"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/picqer/php-barcode-generator/zipball/e9d39681f617705492b609fc3fc58465ef88e8fd",
-                "reference": "e9d39681f617705492b609fc3fc58465ef88e8fd",
+                "url": "https://api.github.com/repos/picqer/php-barcode-generator/zipball/6beada2a30623832ff41b8c7d307c169736b8552",
+                "reference": "6beada2a30623832ff41b8c7d307c169736b8552",
                 "shasum": ""
             },
             "require": {
-                "ext-mbstring": "*",
-                "php": "^8.1"
+                "php": "^8.2"
             },
             "require-dev": {
                 "phpstan/phpstan": "^1.10",
@@ -6599,14 +6598,14 @@
             ],
             "authors": [
                 {
-                    "name": "Nicola Asuni",
-                    "email": "info@tecnick.com",
-                    "homepage": "http://nicolaasuni.tecnick.com"
-                },
-                {
                     "name": "Casper Bakker",
                     "email": "info@picqer.com",
                     "homepage": "https://picqer.com"
+                },
+                {
+                    "name": "Nicola Asuni",
+                    "email": "info@tecnick.com",
+                    "homepage": "http://nicolaasuni.tecnick.com"
                 }
             ],
             "description": "An easy to use, non-bloated, barcode generator in PHP. Creates SVG, PNG, JPG and HTML images from the most used 1D barcode standards.",
@@ -6637,15 +6636,9 @@
             ],
             "support": {
                 "issues": "https://github.com/picqer/php-barcode-generator/issues",
-                "source": "https://github.com/picqer/php-barcode-generator/tree/v2.4.2"
+                "source": "https://github.com/picqer/php-barcode-generator/tree/v3.3.0"
             },
-            "funding": [
-                {
-                    "url": "https://github.com/casperbakker",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-09-18T08:09:33+00:00"
+            "time": "2026-08-22T09:50:32+00:00"
         },
         {
             "name": "predis/predis",


### PR DESCRIPTION
## Summary

- upgrade `picqer/php-barcode-generator` from `^2.4` to `^3.2`
- update the lockfile from v2.4.2 to v3.3.0

Lakasir requires PHP 8.4, which satisfies the v3 PHP requirement. The existing `BarcodeGeneratorSVG::getBarcode()` API used by the label-printing page remains supported.

## Validation

- `composer validate --strict` (passes with the existing exact-version warning)
- exercised the current SVG generation path against v3.3.0 successfully
- `git diff --check`
- `php artisan test` was attempted; database-backed tests cannot connect to the configured `lakasir_testing` MySQL database in this environment